### PR TITLE
fix resource catalouge error when enabiling coremetadata

### DIFF
--- a/src/components/theme/ItemMetadata/ItemMetadata.jsx
+++ b/src/components/theme/ItemMetadata/ItemMetadata.jsx
@@ -123,7 +123,18 @@ const ItemMetadata = (props) => {
                   </Table.Row>
                 )}
 
-                {publisher && (
+                {publisher?.length > 0 ? (
+                  <Table.Row>
+                    <Table.Cell>Organisation</Table.Cell>
+                    <Table.Cell>
+                      {publisher.map((item, i) => (
+                        <div key={i}>
+                          <p>{item.title}</p>
+                        </div>
+                      ))}
+                    </Table.Cell>
+                  </Table.Row>
+                ) : (
                   <Table.Row>
                     <Table.Cell>Organisation</Table.Cell>
                     <Table.Cell>


### PR DESCRIPTION
Testing the integration of eea.coremetadata behavior on freshwater, I discovered that if you enable it on a Resource catalogue datatype it breaks the site because of an undefined error.